### PR TITLE
Fix typo (git => gid) in ExecOptions

### DIFF
--- a/os.d.ts
+++ b/os.d.ts
@@ -52,7 +52,7 @@ declare module "os" {
     stderr?: File;
     env?: { readonly [key: string]: string };
     uid?: number;
-    git?: number;
+    gid?: number;
   }
 
   export class Worker {


### PR DESCRIPTION
It looks like there was a typo in ExecOptions.