### PR TITLE
Add return value to os.exec.

### DIFF
--- a/os.d.ts
+++ b/os.d.ts
@@ -130,7 +130,7 @@ declare module "os" {
   export function signal(signal: number, cb: null): void;
   export function signal(signal: number, cb: undefined): void;
   export function kill(pid: number, signal: number): void;
-  export function exec(args: string[], options?: ExecOptions): void;
+  export function exec(args: string[], options?: ExecOptions): number;
   export function waitpid(
     pid: number,
     options: number


### PR DESCRIPTION
According to this example here: https://github.com/bellard/quickjs/blob/master/tests/test_std.js#L231

The return value for os.exec is the exit code from the process.

I'm not sure what to make of line 238. It seems to say that the return value is the `pid` of the child process?