### PR TITLE
Change error in OSOperationTuple to OSOperationResult.

### DIFF
--- a/os.d.ts
+++ b/os.d.ts
@@ -3,7 +3,7 @@ declare module "os" {
 
   type Success = 0;
   type OSOperationResult = Success | Error;
-  type OSOperationTuple = [str: string, error: Error];
+  type OSOperationTuple = [str: string, error: OSOperationResult];
   type Callback = () => any;
   type TimeoutHandle = number;
 


### PR DESCRIPTION
I've only tested `os.readlink` and `os.realpath` so far but in both cases it seems to be that `error` is `0` or `Success` when everything works as expected. The current change then allows testing that the operation was not successful.

```ts
const [path, error] = os.realpath(scriptArgs[0]);
if (error !== 0) {
  throw new Error(`Call to os.realpath failed with error code ${error}.`);
}
```

P.S. I'm just posting these as I find them. I can collect a few together if you would like but I personally find it easier when MR(s) are short and easy to understand.